### PR TITLE
Wrap training script in main entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,26 +133,70 @@ for i in range(len(train_datas)):
 for i in range(len(test_datas)):
     test_data.append([np.asarray(test_datas[i][0]).reshape(-1), test_datas[i][1]])
 
-input_dimension = 50
-gk_1 = 25
-gk_2 = 10
-out = 4
 
-weights_1 = (np.random.rand(gk_1, input_dimension + 1)-0.5)/1
-weights_2 = (np.random.rand(gk_2, gk_1 + 1)-0.5)/1
-weights_out = (np.random.rand(out, gk_2 + 1)-0.5)/1
+def main():
+    input_dimension = 50
+    gk_1 = 25
+    gk_2 = 10
+    out = 4
 
-weights_1_old = 0
-weights_2_old = 0
-weights_out_old = 0
-Error = 0
-n_learn = 0.01
-alpha = 0.9
+    weights_1 = (np.random.rand(gk_1, input_dimension + 1) - 0.5) / 1
+    weights_2 = (np.random.rand(gk_2, gk_1 + 1) - 0.5) / 1
+    weights_out = (np.random.rand(out, gk_2 + 1) - 0.5) / 1
 
-for j in range(1000):
+    weights_1_old = 0
+    weights_2_old = 0
+    weights_out_old = 0
     Error = 0
-    for i in range(len(train_data)):
-        step_data = train_data[i][0]
+    n_learn = 0.01
+    alpha = 0.9
+
+    for j in range(1000):
+        Error = 0
+        for i in range(len(train_data)):
+            step_data = train_data[i][0]
+            step_data = np.append(step_data, [1])
+
+            vgk1_step = np.matmul(weights_1, step_data)
+            y1 = sigmoid(vgk1_step)
+            y1 = np.append(y1, 1)
+
+            vgk2_step = np.matmul(weights_2, y1)
+            y2 = sigmoid(vgk2_step)
+            y2 = np.append(y2, 1)
+
+            vo_step = np.matmul(weights_out, y2)
+            yo = sigmoid(vo_step)
+
+            step_error = yo - train_data[i][1]
+
+            grd_o = step_error * der_sigmoid(vo_step)
+            grd_2 = np.matmul(np.transpose(weights_out)[:-1], grd_o) * der_sigmoid(vgk2_step)
+            grd_1 = np.matmul(np.transpose(weights_2)[:-1], grd_2) * der_sigmoid(vgk1_step)
+
+            weights_1_new = weights_1 - n_learn * np.matmul(grd_1.reshape(-1, 1), np.transpose(step_data.reshape(-1, 1))) + alpha * (weights_1 - weights_1_old)
+            weights_2_new = weights_2 - n_learn * np.matmul(grd_2.reshape(-1, 1), np.transpose(y1.reshape(-1, 1))) + alpha * (weights_2 - weights_2_old)
+            weights_out_new = weights_out - n_learn * np.matmul(grd_o.reshape(-1, 1), np.transpose(y2.reshape(-1, 1))) + alpha * (weights_out - weights_out_old)
+
+            weights_1_old = weights_1
+            weights_2_old = weights_2
+            weights_out_old = weights_out
+
+            weights_1 = weights_1_new
+            weights_2 = weights_2_new
+            weights_out = weights_out_new
+
+            Error = Error + 0.5 * np.matmul(step_error, np.transpose(step_error))
+
+        if Error / len(train_data) < 0.001:
+            print(j)
+            break
+
+    print(Error / len(train_data))
+
+    Error = 0
+    for i in range(len(test_data)):
+        step_data = test_data[i][0]
         step_data = np.append(step_data, [1])
 
         vgk1_step = np.matmul(weights_1, step_data)
@@ -166,50 +210,12 @@ for j in range(1000):
         vo_step = np.matmul(weights_out, y2)
         yo = sigmoid(vo_step)
 
-        step_error = yo - train_data[i][1]
+        step_error = yo - test_data[i][1]
 
-        grd_o = step_error * der_sigmoid(vo_step)
-        grd_2 = np.matmul(np.transpose(weights_out)[:-1], grd_o) * der_sigmoid(vgk2_step)
-        grd_1 = np.matmul(np.transpose(weights_2)[:-1], grd_2) * der_sigmoid(vgk1_step)
+        Error = Error + 0.5 * np.matmul(step_error, np.transpose(step_error))
 
-        weights_1_new = weights_1 - n_learn * np.matmul(grd_1.reshape(-1, 1), np.transpose(step_data.reshape(-1, 1))) + alpha * (weights_1 - weights_1_old)
-        weights_2_new = weights_2 - n_learn * np.matmul(grd_2.reshape(-1, 1), np.transpose(y1.reshape(-1, 1))) + alpha * (weights_2 - weights_2_old)
-        weights_out_new = weights_out - n_learn * np.matmul(grd_o.reshape(-1, 1), np.transpose(y2.reshape(-1, 1))) + alpha * (weights_out - weights_out_old)
+    print(Error / len(test_data))
 
-        weights_1_old = weights_1
-        weights_2_old = weights_2
-        weights_out_old = weights_out
 
-        weights_1 = weights_1_new
-        weights_2 = weights_2_new
-        weights_out = weights_out_new
-
-        Error = Error + 0.5*np.matmul(step_error, np.transpose(step_error))
-
-    if Error/len(train_data) < 0.001:
-        print(j)
-        break
-
-print(Error/len(train_data))
-
-Error = 0
-for i in range(len(test_data)):
-    step_data = test_data[i][0]
-    step_data = np.append(step_data, [1])
-
-    vgk1_step = np.matmul(weights_1, step_data)
-    y1 = sigmoid(vgk1_step)
-    y1 = np.append(y1, 1)
-
-    vgk2_step = np.matmul(weights_2, y1)
-    y2 = sigmoid(vgk2_step)
-    y2 = np.append(y2, 1)
-
-    vo_step = np.matmul(weights_out, y2)
-    yo = sigmoid(vo_step)
-
-    step_error = yo - test_data[i][1]
-
-    Error = Error + 0.5*np.matmul(step_error, np.transpose(step_error))
-
-print(Error/len(test_data))
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- encapsulate training/evaluation logic inside a `main()` function
- invoke `main()` when executing `main.py`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6852469afefc8329b1d45ad07e45e120